### PR TITLE
feat: `take()`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,30 +34,32 @@ echo $collection['b'];
 
 ## Available Methods
 
-|                         |                             |
-|-------------------------|-----------------------------|
-| [at](#at)               | [average](#average)         |
-| [count](#count)         | [column](#column)           |
-| [diff](#diff)           | [each](#each)               |
-| [every](#every)         | [filter](#filter)           |
-| [fill](#fill)           | [find](#find)               |
-| [findIndex](#findIndex) | [first](#first)             |
-| [flatten](#flatten)     | [groupBy](#groupBy)         |
-| [includes](#includes)   | [isEmpty](#isEmpty)         |
-| [indexOf](#indexOf)     | [items](#items)             |
-| [join](#join)           | [key](#key)                 |
-| [keys](#keys)           | [last](#last)               |
-| [map](#map)             | [merge](#merge)             |
-| [next](#next)           | [pop](#pop)                 |
-| [prev](#prev)           | [push](#push)               |
-| [reduce](#reduce)       | [reverse](#reverse)         |
-| [serialize](#serialize) | [shift](#shift)             |
-| [slice](#slice)         | [sort](#sort)               |
-| [sortDesc](#sortDesc)   | [splice](#splice)           |
-| [sum](#sum)             | [toArray](#toArray)         |
-| [unique](#unique)       | [values](#values)           |
-| [valid](#valid)         | [when](#when)               |
-| [unless](#unless)       | [unserialize](#unserialize) |
+|                             |                     |
+|-----------------------------|---------------------|
+| [at](#at)                   | [average](#average) |
+| [count](#count)             | [column](#column)   |
+| [diff](#diff)               | [each](#each)       |
+| [every](#every)             | [filter](#filter)   |
+| [fill](#fill)               | [find](#find)       |
+| [findIndex](#findIndex)     | [first](#first)     |
+| [flatten](#flatten)         | [groupBy](#groupBy) |
+| [includes](#includes)       | [isEmpty](#isEmpty) |
+| [indexOf](#indexOf)         | [items](#items)     |
+| [join](#join)               | [key](#key)         |
+| [keys](#keys)               | [last](#last)       |
+| [map](#map)                 | [merge](#merge)     |
+| [next](#next)               | [pop](#pop)         |
+| [prev](#prev)               | [push](#push)       |
+| [reduce](#reduce)           | [reverse](#reverse) |
+| [serialize](#serialize)     | [shift](#shift)     |
+| [slice](#slice)             | [sort](#sort)       |
+| [sortDesc](#sortDesc)       | [splice](#splice)   |
+| [sum](#sum)                 | [take](#take)       |
+| [toArray](#toArray)         | [values](#values)   |
+| [unique](#unique)           | [valid](#valid)     |
+| [when](#when)               | [unless](#unless)   |
+| [unserialize](#unserialize) |                     |
+
 
 ### Creation
 
@@ -676,6 +678,32 @@ $collection = new Collection([
 ]);
 return $collection->sum('foo');
 // returns 100
+```
+
+#### take()
+
+Returns a collection with the first or last items based on `$limit`.
+
+```php
+$collection = new Collection([1, 2, 3, 4, 5]);
+return $collection->take(2);
+// returns [1, 2]
+```
+
+You can also use negative number, to get items from the end of collection.
+
+```php
+$collection = new Collection([1, 2, 3, 4, 5]);
+return $collection->take(-2);
+// returns [4, 5]
+```
+
+To preverse keys, you can use the second parameter:
+
+```php
+$collection = new Collection([1, 2, 3, 4, 5]);
+return $collection->take(-2, true);
+// returns [3 => 4, 4 => 5]
 ```
 
 #### unique()

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -411,9 +411,21 @@ trait CollectionTrait
      * Returns a collection with a slice of the items
      * starting at the given index
      */
-    public function slice(int $start, int $end = null): Collection
+    public function slice(int $start, int $end = null, bool $preserveKeys = false): Collection
     {
-        return new static(array_slice($this->items, $start, $end));
+        return new static(array_slice($this->items, $start, $end, $preserveKeys));
+    }
+
+    /**
+     * Returns a collection with the first or last items based on $limit
+     */
+    public function take(int $limit, bool $preserveKeys = false): Collection
+    {
+        if ($limit < 0) {
+            return $this->slice($limit, abs($limit), $preserveKeys);
+        }
+
+        return $this->slice(0, $limit, $preserveKeys);
     }
 
     /**

--- a/tests/InstanceTest.php
+++ b/tests/InstanceTest.php
@@ -547,6 +547,27 @@ class InstanceTest extends TestCase
         $this->assertEquals([4, 5], $new->toArray());
     }
 
+    public function testTake()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5]);
+        $new = $collection->take(2);
+        $this->assertEquals([1, 2], $new->toArray());
+    }
+
+    public function testTakeNegative()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5]);
+        $new = $collection->take(-2);
+        $this->assertEquals([4, 5], $new->toArray());
+    }
+
+    public function testTakeNegativeWithPreservedKeys()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5]);
+        $new = $collection->take(-2, true);
+        $this->assertEquals([3 => 4, 4 => 5], $new->toArray());
+    }
+
     public function testSort()
     {
         $collection = new Collection([3, 1, 5, 2, 4]);


### PR DESCRIPTION
This PR adds `take()` method. This may look a bit redundant because we have `slice()` already, but this method is way easier to use.