### PR TITLE
feat(app): Adds a toFixedArray method to support exporting to an SplFixedArray

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,32 +34,31 @@ echo $collection['b'];
 
 ## Available Methods
 
-|                             |                     |
-|-----------------------------|---------------------|
-| [at](#at)                   | [average](#average) |
-| [count](#count)             | [column](#column)   |
-| [diff](#diff)               | [each](#each)       |
-| [every](#every)             | [filter](#filter)   |
-| [fill](#fill)               | [find](#find)       |
-| [findIndex](#findIndex)     | [first](#first)     |
-| [flatten](#flatten)         | [groupBy](#groupBy) |
-| [includes](#includes)       | [isEmpty](#isEmpty) |
-| [indexOf](#indexOf)         | [items](#items)     |
-| [join](#join)               | [key](#key)         |
-| [keys](#keys)               | [last](#last)       |
-| [map](#map)                 | [merge](#merge)     |
-| [next](#next)               | [pop](#pop)         |
-| [prev](#prev)               | [push](#push)       |
-| [reduce](#reduce)           | [reverse](#reverse) |
-| [serialize](#serialize)     | [shift](#shift)     |
-| [slice](#slice)             | [sort](#sort)       |
-| [sortDesc](#sortDesc)       | [splice](#splice)   |
-| [sum](#sum)                 | [take](#take)       |
-| [toArray](#toArray)         | [values](#values)   |
-| [unique](#unique)           | [valid](#valid)     |
-| [when](#when)               | [unless](#unless)   |
-| [unserialize](#unserialize) |                     |
-
+|                         |                               |
+| ----------------------- | ----------------------------- |
+| [at](#at)               | [average](#average)           |
+| [count](#count)         | [column](#column)             |
+| [diff](#diff)           | [each](#each)                 |
+| [every](#every)         | [filter](#filter)             |
+| [fill](#fill)           | [find](#find)                 |
+| [findIndex](#findIndex) | [first](#first)               |
+| [flatten](#flatten)     | [groupBy](#groupBy)           |
+| [includes](#includes)   | [isEmpty](#isEmpty)           |
+| [indexOf](#indexOf)     | [items](#items)               |
+| [join](#join)           | [key](#key)                   |
+| [keys](#keys)           | [last](#last)                 |
+| [map](#map)             | [merge](#merge)               |
+| [next](#next)           | [pop](#pop)                   |
+| [prev](#prev)           | [push](#push)                 |
+| [reduce](#reduce)       | [reverse](#reverse)           |
+| [serialize](#serialize) | [shift](#shift)               |
+| [slice](#slice)         | [sort](#sort)                 |
+| [sortDesc](#sortDesc)   | [splice](#splice)             |
+| [sum](#sum)             | [take](#take)                 |
+| [toArray](#toArray)     | [toFixedArray](#tofixedarray) |
+| [values](#values)       | [unique](#unique)             |
+| [valid](#valid)         | [when](#when)                 |
+| [unless](#unless)       | [unserialize](#unserialize)   |
 
 ### Creation
 
@@ -125,6 +124,16 @@ Returns the items in the collection as an array.
 $collection = new Collection(['foo', 'bar', 'baz']);
 return $collection->toArray();
 // $collection = ['foo', 'bar', 'baz']
+```
+
+#### toFixedArray()
+
+Returns the items in the collection as an instance of SplFixedArray.
+Fixed arrays use significantly less memory and have better performance.
+
+```php
+$collection = new Collection(['foo', 'bar', 'baz']);
+return $collection->toFixedArray();
 ```
 
 #### items()
@@ -241,7 +250,7 @@ return $collection->average('foo');
 
 #### column()
 
-Returns a new collection from the original collection with single column of collection. 
+Returns a new collection from the original collection with single column of collection.
 
 ```php
 $collection = new Collection([

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -2,6 +2,8 @@
 
 namespace Myth\Collection;
 
+use SplFixedArray;
+
 trait CollectionTrait
 {
     protected array $items = [];
@@ -12,6 +14,15 @@ trait CollectionTrait
     public function toArray()
     {
         return $this->items;
+    }
+
+    /**
+     * Returns the collection of items as a SPLFixedArray
+     * for much lower memory usage, and a bit more speed.
+     */
+    public function toFixedArray(): SplFixedArray
+    {
+        return SplFixedArray::fromArray($this->items);
     }
 
     /**
@@ -112,7 +123,7 @@ trait CollectionTrait
         if ($array instanceof Collection) {
             $array = $array->toArray();
         }
-        
+
         if ($columns === null) {
             return new static(array_diff($this->items, $array));
         }
@@ -601,7 +612,7 @@ trait CollectionTrait
      */
     private function generateKeyFromColumns($item, $columns)
     {
-        return implode('|', array_map(function($column) use ($item) {
+        return implode('|', array_map(function ($column) use ($item) {
             return is_array($item) ? $item[$column] : $item->{$column};
         }, $columns));
     }

--- a/tests/InstanceTest.php
+++ b/tests/InstanceTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 use Myth\Collection\Collection;
+use SplFixedArray;
 
 class InstanceTest extends TestCase
 {
@@ -788,5 +789,13 @@ class InstanceTest extends TestCase
             return $item % 2 === 0;
         });
         $this->assertEquals(['a' => 1, 'c' => 3, 'e' => 5], $new->toArray());
+    }
+
+    public function testToFixedArray()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5]);
+        $new = $collection->toFixedArray();
+        $this->assertInstanceOf(SplFixedArray::class, $new);
+        $this->assertEquals([1, 2, 3, 4, 5], $new->toArray());
     }
 }


### PR DESCRIPTION
SplFixedArray provides a structure with the core of the array's behaviors, but that uses significantly less memory and is faster than the built-in Array. Part of this memory is because it is just a simple array, not the much more complex object that the Array actually is internally. And part is because it must have the size of the array specified when created. 

While it won't be something that's used all of the time, it's something I think worth including, if only to raise awareness of the class. 